### PR TITLE
add working example where dependencies are downgraded

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,15 +1,15 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-	id("org.springframework.boot") version "3.0.2"
-	id("io.spring.dependency-management") version "1.1.0"
-	kotlin("jvm") version "1.7.22"
-	kotlin("plugin.spring") version "1.7.22"
+	id("org.springframework.boot") version "2.3.0.RELEASE"
+	id("io.spring.dependency-management") version "1.0.9.RELEASE"
+	kotlin("jvm") version "1.3.72"
+	kotlin("plugin.spring") version "1.3.72"
 }
 
 group = "com.example"
 version = "0.0.1-SNAPSHOT"
-java.sourceCompatibility = JavaVersion.VERSION_17
+java.sourceCompatibility = JavaVersion.VERSION_11
 
 repositories {
 	mavenCentral()
@@ -22,7 +22,7 @@ dependencies {
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
 	implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
-	implementation("com.expediagroup:graphql-kotlin-spring-server:6.3.6")
+	implementation("com.expediagroup:graphql-kotlin-spring-server:2.1.0")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("io.projectreactor:reactor-test")
 }
@@ -30,7 +30,7 @@ dependencies {
 tasks.withType<KotlinCompile> {
 	kotlinOptions {
 		freeCompilerArgs = listOf("-Xjsr305=strict")
-		jvmTarget = "17"
+		jvmTarget = "1.8"
 	}
 }
 

--- a/src/main/kotlin/com/example/demo/graphql/DemoQuery.kt
+++ b/src/main/kotlin/com/example/demo/graphql/DemoQuery.kt
@@ -1,6 +1,6 @@
 package com.example.demo
 
-import com.expediagroup.graphql.server.operations.Query
+import com.expediagroup.graphql.spring.operations.Query
 import org.springframework.stereotype.Component
 
 @Component


### PR DESCRIPTION
This branch has downgraded dependencies to match the example of [this medium article](https://medium.com/@sven_50828/writing-a-spring-boot-graphql-api-in-kotlin-a306116bb8e0). With this setup, the server bootstraps correctly and one can interact with the server through  `http://localhost:8080/playground`